### PR TITLE
Enable ISM43362 WIFI driver for STM32 DISCO boards

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -22,6 +22,12 @@
             "update-client.bootloader-details" : "0x00007188",
             "update-client.application-details": "(40*1024)"
         },
+        "DISCO_F413ZH": {
+            "network-interface": "WIFI_ISM43362"
+        },
+        "DISCO_L475VG_IOT01A": {
+            "network-interface": "WIFI_ISM43362"
+        },
         "NUCLEO_F429ZI": {
             "target.mbed_app_start"            : "0x08010400",
             "update-client.bootloader-details" : "0x080078CC",
@@ -36,8 +42,16 @@
     },
     "config": {
         "network-interface": {
-            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN",
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ISM43362, WIFI_ODIN",
             "value": "ETHERNET"
+        },
+        "wifi-ssid": {
+            "help": "WiFi SSID",
+            "value": "\"SSID\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"Password\""
         },
         "developer-mode": {
             "help": "Enable Developer mode to skip Factory enrollment",


### PR DESCRIPTION
Hi

Easy Connect has been updated for ISM 43362 WIFI driver:
https://github.com/ARMmbed/easy-connect/pull/98

2 DISCO STM32 boards have this WIFI module integrated:
- [DISCO_L475VG_IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/)
- [DISCO_F413ZH](https://os.mbed.com/platforms/ST-Discovery-F413H/) 

@bcostm @adustm @lmestm 