### PR TITLE
Create wnc14a2a.json

### DIFF
--- a/wnc14a2a.json
+++ b/wnc14a2a.json
@@ -1,0 +1,64 @@
+{
+    "macros": [
+        "PLATFORM_ENABLE_LED=1",
+        "PAL_USER_DEFINED_CONFIGURATION=\"sotp_fs_config_MbedOS.h\"",
+        "ARM_UC_USE_PAL_BLOCKDEVICE=1",
+        "MBED_CLOUD_CLIENT_UPDATE_STORAGE=ARM_UCP_FLASHIAP_BLOCKDEVICE"
+    ],
+    "target_overrides": {
+        "*": {
+            "platform.stdio-baud-rate": 115200,
+            "platform.stdio-convert-newlines": true,
+            "mbed-client.event-loop-size": 1024,
+            "mbed-trace.enable": null,
+            "storage-selector.filesystem" : "FAT",
+            "storage-selector.mount-point": "\"sd\"",
+            "storage-selector.storage"    : "SD_CARD",
+            "update-client.storage-address"  : "(1024*1024*64)",
+            "update-client.storage-size"     : "(1024*1024*2)",
+            "update-client.storage-locations": "1"
+        },
+        "K64F": {
+            "target.mbed_app_start"            : "0x0000a400",
+            "update-client.bootloader-details" : "0x00007188",
+            "update-client.application-details": "(40*1024)"
+        },
+        "NUCLEO_F429ZI": {
+            "target.mbed_app_start"            : "0x08010400",
+            "update-client.bootloader-details" : "0x080078CC",
+            "update-client.application-details": "(0x08000000+64*1024)"
+        },
+        "UBLOX_EVK_ODIN_W2": {
+            "target.mbed_app_start"            : "0x08010400",
+            "target.device_has_remove": ["EMAC"],
+            "update-client.bootloader-details" : "0x08007300",
+            "update-client.application-details": "(0x08000000+64*1024)"
+        }
+    },
+    "config": {
+        "network-interface": {
+            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, CELLULAR_WNC14A2A",
+            "value": "CELLULAR_WNC14A2A"
+        },
+        "developer-mode": {
+            "help": "Enable Developer mode to skip Factory enrollment",
+            "value": 1
+        },
+        "button-pinname": {
+            "help": "PinName for button.",
+            "value": "BUTTON1"
+        },
+        "led-pinname": {
+            "help": "PinName for led, which is attached to led blink resource.",
+            "value": "LED_RED"
+        },
+        "wnc_debug": {
+            "help" : "enable or disable WNC debug messages.",
+            "value": 0
+        },
+        "wnc_debug_setting": {
+            "help" : "bit value 1 and/or 2 enable WncController debug output, bit value 4 enables mbed driver debug output.",
+            "value": "0x0c"
+        }
+    }
+}


### PR DESCRIPTION
This is a config file for the wnc14a2a that could be placed in the configs directory to allow users to create a wnc image via 'mbed compile -m K64F -t GCC_ARM --app-config configs/wnc14a2a.json'

@dlfryar 

