### PR TITLE
NUCLEO_F411RE: Use default implementation of NV Seed

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -58,7 +58,13 @@
             "idw0xx1.provide-default": true,
             "idw0xx1.tx": "PA_9",
             "idw0xx1.rx": "PA_10",
-            "target.macros_remove"                  : ["MBEDTLS_CONFIG_HW_SUPPORT"]
+            "target.macros_remove"                  : ["MBEDTLS_CONFIG_HW_SUPPORT"],
+            "target.extra_labels_add": ["PSA"],
+            "target.macros_add": [
+                "MBEDTLS_ENTROPY_NV_SEED=1",
+                "MBEDTLS_PLATFORM_NV_SEED_READ_MACRO=mbed_default_seed_read",
+                "MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO=mbed_default_seed_write"
+            ]
         }
     },
     "config": {


### PR DESCRIPTION
Pretend to be a PSA target so that the default NV Seed implementation
provided for use by PSA targets will be available for use on the
NUCLEO_F411RE, a non-PSA target that also lacks a TRNG.

Note that enabling this requires the device to be manufactured with an
external entropy source to be used as the initial NV Seed. Any use of
cryptography will fail at run-time until the initial NV Seed is
injected.